### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "type": "package",
     "minimum-stability": "dev",
     "require": {
-        "illuminate/support": "~5.5"
+        "illuminate/support": "5.5.*"
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.