### PR TITLE
Made logic to get mobile phone number overridable.

### DIFF
--- a/src/Providers/MessageBirdVerify.php
+++ b/src/Providers/MessageBirdVerify.php
@@ -110,12 +110,12 @@ class MessageBirdVerify extends BaseProvider implements TwoFactorProvider, SMSTo
      */
     public function sendSMSToken(User $user) : void
     {
-        if (!$user->mobile) {
+        if (!$user->getMobile()) {
             throw new Exception("No mobile phone number found for user {$user->id}.");
         }
 
         $verify = new Verify;
-        $verify->recipient = $user->mobile;
+        $verify->recipient = $user->getMobile();
 
         $result = $this->client->verify->create(
             $verify,

--- a/src/TwoFactorAuthenticable.php
+++ b/src/TwoFactorAuthenticable.php
@@ -9,6 +9,15 @@ use Illuminate\Support\Facades\DB;
 trait TwoFactorAuthenticable
 {
     /**
+     * Get the mobile phone number to be used. Override in your User model to suit your application.
+     * @return string
+     */
+    public function getMobile() : string
+    {
+        return $this->mobile;
+    }
+
+    /**
      * Get the two-factor auth record associated with the user.
      *
      * @return \Illuminate\Database\Eloquent\Relations\HasOne


### PR DESCRIPTION
Hi Michael,

another PR. I have put the logic to get the user's mobile phone number into a method of the trait. This is overridable by the developer in the model using the trait. So this way other field(s), model, or a non-database source could be used. And if the value would need tweaking, this is also possible, 

This makes the add mobile migration fully optional. If you like the change, its functionality should be documented of course.

Best regards, Kim.
