### PR TITLE
Autocomplete of 2FA on mobile devices

### DIFF
--- a/src/resources/views/form.blade.php
+++ b/src/resources/views/form.blade.php
@@ -15,7 +15,7 @@
                             <label for="token" class="col-md-4 col-form-label text-md-right">@lang('twofactor-auth::twofactor-auth.label')</label>
 
                             <div class="col-md-6">
-                                <input id="token" type="text" class="form-control{{ $errors->has('token') ? ' is-invalid' : '' }}" name="token" value="{{ old('token') }}" required autofocus>
+                                <input id="token" type="text" autocomplete="one-time-code" class="form-control{{ $errors->has('token') ? ' is-invalid' : '' }}" name="token" value="{{ old('token') }}" required autofocus>
 
                                 @if ($errors->has('token'))
                                     <span class="invalid-feedback" role="alert">


### PR DESCRIPTION
Hi @michaeldzjap I've added an autocomplete attribute to the input field so that iOS and Android users can take advantage of the native built-in suggestions.

On iOS this will provide a shortcut to the user to fill in the input with the code that was sent to them via SMS. 