### PR TITLE
$this->app -> app() fixes ErrorException in Laravel 8

### DIFF
--- a/src/TwoFactorAuthManager.php
+++ b/src/TwoFactorAuthManager.php
@@ -29,7 +29,7 @@ class TwoFactorAuthManager extends Manager
     protected function createMessageBirdDriver(): TwoFactorProvider
     {
         return new MessageBirdVerify(
-            new Client($this->app['config']['twofactor-auth.providers.messagebird.key'])
+            new Client(app()['config']['twofactor-auth.providers.messagebird.key'])
         );
     }
 
@@ -50,7 +50,7 @@ class TwoFactorAuthManager extends Manager
      */
     public function getDefaultDriver(): string
     {
-        return $this->app['config']['twofactor-auth.default'];
+        return app()['config']['twofactor-auth.default'];
     }
 
     /**
@@ -61,6 +61,6 @@ class TwoFactorAuthManager extends Manager
      */
     public function setDefaultDriver(string $name): void
     {
-        $this->app['config']['twofactor-auth.default'] = $name;
+        app()['config']['twofactor-auth.default'] = $name;
     }
 }


### PR DESCRIPTION
When using this package in an upgraded from Laravel 7 to Laravel 8 project I bump into ErrorExceptions in TwoFactorAuthManager.php 

When changing $this->app to app() it seems to work fine again.

Great package btw!