### PR TITLE
Reject float tokens

### DIFF
--- a/src/Http/Requests/VerifySMSToken.php
+++ b/src/Http/Requests/VerifySMSToken.php
@@ -28,7 +28,7 @@ class VerifySMSToken extends FormRequest
     public function rules()
     {
         return [
-            'token' => 'required|string|numeric',
+            'token' => ['required', 'string', 'regex:/^\d+$/'],
         ];
     }
 }


### PR DESCRIPTION
Prevent tokens with e.g. a dot in it to be interpreted as a float, pass validation and cause an "Token must be a string of integer" exception.

Entering the token `123.123` causes the error.

<img width="1493" alt="Screenshot 2025-01-28 at 08 31 41" src="https://github.com/user-attachments/assets/f14d5f44-663a-4b79-8c83-70b8394eb75e" />
